### PR TITLE
Release 0.7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Maven Central](https://img.shields.io/maven-central/v/de.javawi.jstun/jstun.svg)](http://search.maven.org/#search|gav|1|g:"de.javawi.jstun"%20AND%20a:"jstun")
+
 "JSTUN" - Java Simple Traversal of User Datagram Protocol (UDP) Through Network Address Translation (NAT)
 =========================================================================================================
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ How does it work?
 -----------------
 STUN is described in RFC 3489. A STUN server is running on jstun.javawi.de:3478.
 
-Just invoke "java -cp jstun-0.7.3.jar:slf4j-api-1.5.6.jar:slf4j-jdk14-1.5.6.jar de.javawi.jstun.test.demo.DiscoveryTestDemo" or use the de.javawi.jstun.test.demo.DiscoveryTest and de.javawi.jstun.test.demo.BindingLifetimeTest classes in order to start the STUN client.
+Just invoke "java -cp jstun-0.7.4.jar:slf4j-api-1.5.6.jar:slf4j-jdk14-1.5.6.jar de.javawi.jstun.test.demo.DiscoveryTestDemo" or use the de.javawi.jstun.test.demo.DiscoveryTest and de.javawi.jstun.test.demo.BindingLifetimeTest classes in order to start the STUN client.
 
-A "JSTUN"-based STUN server is also available. Just try it (assuming you own a dual-homed machine): java -cp jstun-0.7.3.jar:slf4j-api-1.5.6.jar:slf4j-jdk14-1.5.6.jar de.javawi.jstun.test.demo. StunServer PORT1 IP1 PORT2 IP2.
+A "JSTUN"-based STUN server is also available. Just try it (assuming you own a dual-homed machine): java -cp jstun-0.7.4.jar:slf4j-api-1.5.6.jar:slf4j-jdk14-1.5.6.jar de.javawi.jstun.test.demo. StunServer PORT1 IP1 PORT2 IP2.
  
 
 What about RFC 5389?

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.javawi.jstun</groupId>
-    <version>0.7.4</version>
+    <version>0.7.5-SNAPSHOT</version>
     <artifactId>jstun</artifactId>
     <packaging>jar</packaging>
     <name>JSTUN</name>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.javawi.jstun</groupId>
-    <version>0.7.4-SNAPSHOT</version>
+    <version>0.7.4</version>
     <artifactId>jstun</artifactId>
     <packaging>jar</packaging>
     <name>JSTUN</name>


### PR DESCRIPTION
This PR contains ~two~ three commits, which should _not_ be squashed.

The first commit, fb9edbe2f09cb4c4a517c43d73c70a5d31faede2, identifies the state of the code that was released as a Maven artifact as version 0.7.4.

The second commit updates the version number to 0.7.5-SNAPSHOT. I've done this immediately after the commit, to prevent multiple releases of different software under the same version identifier. The third commit adds a banner to the Github project page, referencing the latest Maven release of the project.

I'd advice you to mark fb9edbe2f09cb4c4a517c43d73c70a5d31faede2 as a release in Github. Additionally, you could consider updating the website at http://jstun.javawi.de

The released Maven artifacts are already synced to the Central Maven Repository. They can be found here: http://repo1.maven.org/maven2/de/javawi/jstun/jstun/0.7.4/ Note that the various search engines that are typically used to browse this repository can take a few hours to pick up the new files.