### PR TITLE
Wrong byte offsets for error codes

### DIFF
--- a/src/main/java/de/javawi/jstun/attribute/ErrorCode.java
+++ b/src/main/java/de/javawi/jstun/attribute/ErrorCode.java
@@ -85,10 +85,10 @@ public class ErrorCode extends MessageAttribute {
 			if (data.length < 4) {
 				throw new MessageAttributeParsingException("Data array too short");
 			}
-			byte classHeaderByte = data[3];
+			byte classHeaderByte = data[2];
 			int classHeader = Utility.oneByteToInteger(classHeaderByte);
 			if ((classHeader < 1) || (classHeader > 6)) throw new MessageAttributeParsingException("Class parsing error");
-			byte numberByte = data[4];
+			byte numberByte = data[3];
 			int number = Utility.oneByteToInteger(numberByte);
 			if ((number < 0) || (number > 99)) throw new MessageAttributeParsingException("Number parsing error");
 			int responseCode = (classHeader * 100) + number;


### PR DESCRIPTION
Hey,
it seems you had a +1 index offset error at parsing the error code attribute. Here for reference: https://tools.ietf.org/html/rfc5389#section-15.6
kind regards