### PR TITLE
Fix ErrorCode.getBytes()

### DIFF
--- a/src/main/java/de/javawi/jstun/attribute/ErrorCode.java
+++ b/src/main/java/de/javawi/jstun/attribute/ErrorCode.java
@@ -62,8 +62,8 @@ public class ErrorCode extends MessageAttribute {
 		if ((length % 4) != 0) {
 			length += 4 - (length % 4);
 		}
-		// message attribute header
-		length += 4;
+		// message attribute header + error code header
+		length += 8;
 		byte[] result = new byte[length];
 		// message attribute header
 		// type


### PR DESCRIPTION
The issue occurs because the calculation of the length of the serialized `ErrorCode` attribute doesn’t account for the size of the "error code header", just the "message attribute header", leading to the next exception when attempting to copy the resulting bytes for `responseCode=420`:

```
java.lang.ArrayIndexOutOfBoundsException: arraycopy: last destination index 24 out of bounds for byte[20]
	at java.base/java.lang.System.arraycopy(Native Method)
	at de.javawi.jstun.attribute.ErrorCode.getBytes(ErrorCode.java:79)
	at de.javawi.jstun.attribute.MessageAttribute.getLength(MessageAttribute.java:76)
	at de.javawi.jstun.header.MessageHeader.getBytes(MessageHeader.java:121)
```

