### PR TITLE
Add IPv6 Support

### DIFF
--- a/src/test/java/de/javawi/jstun/attribute/MappedAddressTest.java
+++ b/src/test/java/de/javawi/jstun/attribute/MappedAddressTest.java
@@ -1,9 +1,9 @@
 /*
- * This file is part of JSTUN. 
- * 
+ * This file is part of JSTUN.
+ *
  * Copyright (c) 2005 Thomas King <king@t-king.de> - All rights
  * reserved.
- * 
+ *
  * This software is licensed under either the GNU Public License (GPL),
  * or the Apache 2.0 license. Copies of both license agreements are
  * included in this distribution.
@@ -11,26 +11,58 @@
 
 package de.javawi.jstun.attribute;
 
+import de.javawi.jstun.header.MessageHeader;
+import de.javawi.jstun.header.MessageHeaderInterface;
+import de.javawi.jstun.util.UtilityException;
 import junit.framework.TestCase;
 
+import java.io.IOException;
+import java.net.*;
+
 public class MappedAddressTest extends TestCase {
-	MappedAddress ma;
-	byte[] data;
+	MappedAddress maV4;
+	MappedAddress maV6;
+	byte[] dataV4;
+	byte[] dataV6;
+
 	public MappedAddressTest(String mesg) {
 		super(mesg);
 	}
-	
+
 	public void setUp() throws Exception {
-		data = new byte[8];
-		data[0] = 0;
-		data[1] = 1;
-		data[2] = -8;
-		data[3] = 96;
-		data[4] = 84;
-		data[5] = 56;
-		data[6] = -23;
-		data[7] = 76;
-		ma = (MappedAddress) MappedAddress.parse(data);
+		dataV4 = new byte[8];
+		dataV4[0] = 0; // IPv4 family
+		dataV4[1] = 1;
+		dataV4[2] = -8; // Port
+		dataV4[3] = 96;
+		dataV4[4] = 84;
+		dataV4[5] = 56;
+		dataV4[6] = -23;
+		dataV4[7] = 76;
+		maV4 = (MappedAddress) MappedAddress.parse(dataV4);
+
+		dataV6 = new byte[20];
+		dataV6[0] = 0; // IPv6 family
+		dataV6[1] = 2;
+		dataV6[2] = -8; // Port
+		dataV6[3] = 96;
+		dataV6[4] = (byte)0x20;
+		dataV6[5] = (byte)0x01;
+		dataV6[6] = (byte)0x0d;
+		dataV6[7] = (byte)0xb8;
+		dataV6[8] = (byte)0x85;
+		dataV6[9] = (byte)0xa3;
+		dataV6[10] = (byte)0x08;
+		dataV6[11] = (byte)0xd3;
+		dataV6[12] = (byte)0x13;
+		dataV6[13] = (byte)0x19;
+		dataV6[14] = (byte)0x8a;
+		dataV6[15] = (byte)0x2e;
+		dataV6[16] = (byte)0x03;
+		dataV6[17] = (byte)0x70;
+		dataV6[18] = (byte)0x73;
+		dataV6[19] = (byte)0x44;
+		maV6 = (MappedAddress) MappedAddress.parse(dataV6);
 	}
 
 	/*
@@ -43,22 +75,54 @@ public class MappedAddressTest extends TestCase {
 	/*
 	 * Test method for 'de.javawi.jstun.attribute.MappedResponseChangedSourceAddressReflectedFrom.getBytes()'
 	 */
-	public void testGetBytes() {
+	public void testV4GetBytes() {
 		try {
-			byte[] result = ma.getBytes();
+			byte[] result = maV4.getBytes();
 
 			assertTrue(result[0] == 0);
 			assertTrue(result[1] == 1);
 			assertTrue(result[2] == 0);
 			assertTrue(result[3] == 8);
-			assertTrue(result[4] == data[0]);
-			assertTrue(result[5] == data[1]);
-			assertTrue(result[6] == data[2]);
-			assertTrue(result[7] == data[3]);
-			assertTrue(result[8] == data[4]);
-			assertTrue(result[9] == data[5]);
-			assertTrue(result[10] == data[6]);
-			assertTrue(result[11] == data[7]);
+			assertTrue(result[4] == dataV4[0]);
+			assertTrue(result[5] == dataV4[1]);
+			assertTrue(result[6] == dataV4[2]);
+			assertTrue(result[7] == dataV4[3]);
+			assertTrue(result[8] == dataV4[4]);
+			assertTrue(result[9] == dataV4[5]);
+			assertTrue(result[10] == dataV4[6]);
+			assertTrue(result[11] == dataV4[7]);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	/*
+	 * Test method for 'de.javawi.jstun.attribute.MappedResponseChangedSourceAddressReflectedFrom.getBytes()'
+	 */
+	public void testV6GetBytes() {
+		try {
+			byte[] result = maV6.getBytes();
+
+			assertTrue(result[0] == 0);
+			assertTrue(result[1] == 1);
+			assertTrue(result[2] == 0);
+			assertTrue(result[3] == 8);
+			assertTrue(result[4] == dataV6[0]);
+			assertTrue(result[5] == dataV6[1]);
+			assertTrue(result[6] == dataV6[2]);
+			assertTrue(result[7] == dataV6[3]);
+			assertTrue(result[8] == dataV6[4]);
+			assertTrue(result[9] == dataV6[5]);
+			assertTrue(result[10] == dataV6[6]);
+			assertTrue(result[11] == dataV6[7]);
+			assertTrue(result[12] == dataV6[8]);
+			assertTrue(result[13] == dataV6[9]);
+			assertTrue(result[14] == dataV6[10]);
+			assertTrue(result[15] == dataV6[11]);
+			assertTrue(result[16] == dataV6[12]);
+			assertTrue(result[17] == dataV6[13]);
+			assertTrue(result[18] == dataV6[14]);
+			assertTrue(result[19] == dataV6[15]);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -68,17 +132,27 @@ public class MappedAddressTest extends TestCase {
 	 * Test method for 'de.javawi.jstun.attribute.MappedResponseChangedSourceAddressReflectedFrom.getPort()'
 	 */
 	public void testGetPort() {
-		assertTrue(ma.getPort() == 63584);
+		assertTrue(maV4.getPort() == 63584);
+		assertTrue(maV6.getPort() == 63584);
 	}
 
 	/*
 	 * Test method for 'de.javawi.jstun.attribute.MappedResponseChangedSourceAddressReflectedFrom.getAddress()'
 	 */
-	public void testGetAddress() {
+	public void testV4GetAddress() {
 		try {
-			System.out.println(ma.getAddress().toString());
-			assertTrue(ma.getAddress().equals(new de.javawi.jstun.util.Address("84.56.233.76")));
-			
+			assertTrue(maV4.getAddress().equals(new de.javawi.jstun.util.Address("84.56.233.76")));
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	/*
+	 * Test method for 'de.javawi.jstun.attribute.MappedResponseChangedSourceAddressReflectedFrom.getAddress()'
+	 */
+	public void testV6GetAddress() {
+		try {
+			assertTrue(maV6.getAddress().equals(new de.javawi.jstun.util.Address("2001:db8:85a3:8d3:1319:8a2e:370:7344")));
 		} catch (Exception e) {
 			e.printStackTrace();
 		}

--- a/src/test/java/de/javawi/jstun/util/AddressTest.java
+++ b/src/test/java/de/javawi/jstun/util/AddressTest.java
@@ -14,23 +14,51 @@ package de.javawi.jstun.util;
 import junit.framework.TestCase;
 
 public class AddressTest extends TestCase {
-	Address address;
+	Address ipv4Address;
+	Address ipv6Address;
 	
 	public AddressTest(String mesg) {
 		super(mesg);
 	}
 
 	protected void setUp() throws Exception {
-		address = new Address("192.168.100.1");
+		ipv4Address = new Address("192.168.100.1");
+		ipv6Address = new Address("2001:0db8:85a3:08d3:1319:8a2e:0370:7344");
 	}
 
 	/*
 	 * Test method for 'de.javawi.jstun.util.Address.Address(int, int, int, int)'
 	 */
-	public void testAddressIntIntIntInt() {
+	public void testAddressV4IntIntIntInt() {
 		try {
 			Address comp = new Address(192,168,100,1);
-			assertTrue(address.equals(comp));
+			assertTrue(ipv4Address.equals(comp));
+		} catch (UtilityException ue) {
+			ue.printStackTrace();
+		}
+	}
+
+	/*
+	 * Test method for 'de.javawi.jstun.util.Address.Address(int[])'
+	 */
+	public void testAddressV4IntArray() {
+		try {
+			int[] data = {192, 168, 100, 1};
+			Address comp = new Address(data);
+			assertTrue(ipv4Address.equals(comp));
+		} catch (UtilityException ue) {
+			ue.printStackTrace();
+		}
+	}
+
+	/*
+	 * Test method for 'de.javawi.jstun.util.Address.Address(int[])'
+	 */
+	public void testAddressV6Int16Array() {
+		try {
+			int[] data = {0x20, 0x01, 0x0d, 0xb8, 0x85, 0xa3, 0x08, 0xd3, 0x13, 0x19, 0x8a, 0x2e, 0x03, 0x70, 0x73, 0x44};
+			Address comp = new Address(data);
+			assertTrue(ipv6Address.equals(comp));
 		} catch (UtilityException ue) {
 			ue.printStackTrace();
 		}
@@ -39,10 +67,22 @@ public class AddressTest extends TestCase {
 	/*
 	 * Test method for 'de.javawi.jstun.util.Address.Address(String)'
 	 */
-	public void testAddressString() {
+	public void testAddressV4String() {
 		try {
 			Address comp = new Address("192.168.100.1");
-			assertTrue(address.equals(comp));
+			assertTrue(ipv4Address.equals(comp));
+		} catch (UtilityException ue) {
+			ue.printStackTrace();
+		}
+	}
+
+	/*
+	 * Test method for 'de.javawi.jstun.util.Address.Address(String)'
+	 */
+	public void testAddressV6String() {
+		try {
+			Address comp = new Address("2001:0db8:85a3:08d3:1319:8a2e:0370:7344");
+			assertTrue(ipv6Address.equals(comp));
 		} catch (UtilityException ue) {
 			ue.printStackTrace();
 		}
@@ -51,34 +91,51 @@ public class AddressTest extends TestCase {
 	/*
 	 * Test method for 'de.javawi.jstun.util.Address.Address(byte[])'
 	 */
-	public void testAddressByteArray() {
+	public void testAddressV4ByteArray() {
 		try {
 			byte[] data = {(byte)192, (byte)168, (byte)100, (byte)1};
 			Address comp = new Address(data);
-			assertTrue(address.equals(comp));
+			assertTrue(ipv4Address.equals(comp));
 		} catch (UtilityException ue) {
 			ue.printStackTrace();
 		}
 	}
 
 	/*
-	 * Test method for 'de.javawi.jstun.util.Address.toString()'
+	 * Test method for 'de.javawi.jstun.util.Address.Address(byte[])'
 	 */
-	public void testToString() {
+	public void testAddressV6ByteArray() {
 		try {
-			Address comp = new Address("192.168.100.1");
-			assertTrue(address.equals(comp));
+			byte[] data = {(byte)0x20, (byte)0x01, (byte)0x0d, (byte)0xb8, (byte)0x85, (byte)0xa3, (byte)0x08, (byte)0xd3, (byte)0x13, (byte)0x19, (byte)0x8a, (byte)0x2e, (byte)0x03, (byte)0x70, (byte)0x73, (byte)0x44};
+			Address comp = new Address(data);
+			assertTrue(ipv6Address.equals(comp));
 		} catch (UtilityException ue) {
 			ue.printStackTrace();
 		}
+	}
+	/*
+	 * Test method for 'de.javawi.jstun.util.Address.toString()'
+	 */
+	public void testV4ToString() {
+        String comp = "192.168.100.1";
+        assertTrue(ipv4Address.toString().equals(comp));
+    }
+
+	/*
+	 * Test method for 'de.javawi.jstun.util.Address.toString()'
+	 */
+	public void testV6ToString() {
+		String comp = "2001:db8:85a3:8d3:1319:8a2e:370:7344";
+
+        assertEquals(ipv6Address.toString(), comp);
 	}
 
 	/*
 	 * Test method for 'de.javawi.jstun.util.Address.getBytes()'
 	 */
-	public void testGetBytes() {
+	public void testV4GetBytes() {
 		try {
-			byte[] data = address.getBytes();
+			byte[] data = ipv4Address.getBytes();
 			assertTrue(data[0] == (byte)192);
 			assertTrue(data[1] == (byte)168);
 			assertTrue(data[2] == (byte)100);
@@ -90,14 +147,42 @@ public class AddressTest extends TestCase {
 	}
 
 	/*
+	 * Test method for 'de.javawi.jstun.util.Address.getBytes()'
+	 */
+	public void testV6GetBytes() {
+		try {
+			byte[] data = ipv6Address.getBytes();
+			assertTrue(data[0] == (byte)0x20);
+			assertTrue(data[1] == (byte)0x01);
+			assertTrue(data[2] == (byte)0x0d);
+			assertTrue(data[3] == (byte)0xb8);
+			assertTrue(data[4] == (byte)0x85);
+			assertTrue(data[5] == (byte)0xa3);
+			assertTrue(data[6] == (byte)0x08);
+			assertTrue(data[7] == (byte)0xd3);
+			assertTrue(data[8] == (byte)0x13);
+			assertTrue(data[9] == (byte)0x19);
+			assertTrue(data[10] == (byte)0x8a);
+			assertTrue(data[11] == (byte)0x2e);
+			assertTrue(data[12] == (byte)0x03);
+			assertTrue(data[13] == (byte)0x70);
+			assertTrue(data[14] == (byte)0x73);
+			assertTrue(data[15] == (byte)0x44);
+		} catch (UtilityException ue) {
+			ue.printStackTrace();
+		}
+
+	}
+
+	/*
 	 * Test method for 'de.javawi.jstun.util.Address.getInetAddress()'
 	 */
-	public void testGetInetAddress() {
+	public void testV4GetInetAddress() {
 		try {
 			Address comp = new Address("192.168.100.1");
-			assertTrue(address.getInetAddress().equals(comp.getInetAddress()));
+			assertTrue(ipv4Address.getInetAddress().equals(comp.getInetAddress()));
 			comp = new Address("192.168.100.2");
-			assertFalse(address.getInetAddress().equals(comp.getInetAddress()));
+			assertFalse(ipv4Address.getInetAddress().equals(comp.getInetAddress()));
 		} catch (UtilityException ue) {
 			ue.printStackTrace();
 		} catch (java.net.UnknownHostException uhe) {
@@ -105,15 +190,48 @@ public class AddressTest extends TestCase {
 		}
 	}
 
+
+	/*
+	 * Test method for 'de.javawi.jstun.util.Address.getInetAddress()'
+	 */
+	public void testV6GetInetAddress() {
+		try {
+			Address comp = new Address("2001:0db8:85a3:08d3:1319:8a2e:0370:7344");
+			assertTrue(ipv6Address.getInetAddress().equals(comp.getInetAddress()));
+			comp = new Address("2001:0db8:85a3:08d3:1319:8a2e:0370:7345");
+			assertFalse(ipv6Address.getInetAddress().equals(comp.getInetAddress()));
+		} catch (UtilityException ue) {
+			ue.printStackTrace();
+		} catch (java.net.UnknownHostException uhe) {
+			uhe.printStackTrace();
+		}
+	}
+
+
+
 	/*
 	 * Test method for 'de.javawi.jstun.util.Address.equals(Object)'
 	 */
-	public void testEqualsObject() {
+	public void testV4EqualsObject() {
 		try {
 			Address comp = new Address("192.168.100.1");
-			assertTrue(address.equals(comp));
+			assertTrue(ipv4Address.equals(comp));
 			comp = new Address("192.168.100.2");
-			assertFalse(address.equals(comp));
+			assertFalse(ipv4Address.equals(comp));
+		} catch (UtilityException ue) {
+			ue.printStackTrace();
+		}
+	}
+
+	/*
+	 * Test method for 'de.javawi.jstun.util.Address.equals(Object)'
+	 */
+	public void testV6EqualsObject() {
+		try {
+			Address comp = new Address("2001:0db8:85a3:08d3:1319:8a2e:0370:7344");
+			assertTrue(ipv6Address.equals(comp));
+			comp = new Address("2001:0db8:85a3:08d3:1319:8a2e:0370:7345");
+			assertFalse(ipv6Address.equals(comp));
 		} catch (UtilityException ue) {
 			ue.printStackTrace();
 		}


### PR DESCRIPTION
Adds IPv6 Support for Mapped Addresses and to be able to STUN using an IPv6 interface. Resolves #20

Tests have been added as well.

Features:
- Deprecates Address(int octetOne, int octetTwo, int octetThree, int octetFour) in favour for Address(int[] octets)
- Adds IPv6 support to Address
- Adds IPv6 support for MappedAddress parsing (0x0002 family)
- Adds tests for both V6 Address and MappedAddress

Tested by running a simple script to create a STUN connection to IPv4 and IPv6 Google STUN servers.

For end users when implementing this, make sure your receive buffer is at least 44 bytes as v6 packets are bigger than v4 packets. Previously, a STUN in v4 would only require 32 bytes.