### PR TITLE
Add an "Automatic module name" entry to the manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ logging_server.txt
 target/
 .idea/
 *.iml
+.classpath
+.project
+.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,11 @@
 
     <build>
         <plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>3.3.0</version>
+			</plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.javawi.jstun</groupId>
-    <version>0.7.5-SNAPSHOT</version>
+    <version>0.7.6-SNAPSHOT</version>
     <artifactId>jstun</artifactId>
     <packaging>jar</packaging>
     <name>JSTUN</name>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.11.2</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -79,8 +79,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,9 @@
                             <addClasspath>true</addClasspath>
                             <mainClass>de.javawi.jstun.test.demo.StunServer</mainClass>
                         </manifest>
+						<manifestEntries>
+							<Automatic-Module-Name>de.javawi.jstun</Automatic-Module-Name>
+						</manifestEntries>
                     </archive>
                 </configuration>
             </plugin>


### PR DESCRIPTION
A modular Java 17 project requires to declare dependencies to other modules. When a dependency is not modular, it must at least declare a module name in its manifest to be usable:

```
Automatic-Module-Name: de.javawi.jstun
```

From this PR, only e8ffcdd9d58ad73a798384b5c9e7d3ff344da294 is technically necessary, but I needed the other changes to be able to build the project with a recent JDK.